### PR TITLE
Remove superfluous calls to RCTConvert

### DIFF
--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -72,7 +72,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString)
 {
-    [SentryClient setShared:[[SentryClient alloc] initWithDsnString:[RCTConvert NSString:dsnString]]];
+    [SentryClient setShared:[[SentryClient alloc] initWithDsnString:dsnString]];
     [[SentryClient shared] startCrashHandler];
 }
 
@@ -111,7 +111,7 @@ RCT_EXPORT_METHOD(activateStacktraceMerging:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(captureMessage:(NSString * _Nonnull)message level:(int)level)
 {
-    [[SentryClient shared] captureMessage:[RCTConvert NSString:message] level:level];
+    [[SentryClient shared] captureMessage:message level:level];
 }
 
 RCT_EXPORT_METHOD(setLogLevel:(int)level)
@@ -121,12 +121,12 @@ RCT_EXPORT_METHOD(setLogLevel:(int)level)
 
 RCT_EXPORT_METHOD(setExtras:(NSDictionary * _Nonnull)extras)
 {
-    [SentryClient shared].extra = [RCTConvert NSDictionary:extras];
+    [SentryClient shared].extra = extras;
 }
 
 RCT_EXPORT_METHOD(setTags:(NSDictionary * _Nonnull)tags)
 {
-    [SentryClient shared].tags = [self sanitizeDictionary:[RCTConvert NSDictionary:tags]];
+    [SentryClient shared].tags = [self sanitizeDictionary:tags];
 }
 
 RCT_EXPORT_METHOD(setUser:(NSDictionary * _Nonnull)user)


### PR DESCRIPTION
These calls to RCTConvert are inferred based on the types passed into
the macro, according to the RN docs.

http://facebook.github.io/react-native/releases/0.42/docs/native-modules-ios.html#argument-types