### PR TITLE
Add installWithBridge method

### DIFF
--- a/ios/RNSentry.h
+++ b/ios/RNSentry.h
@@ -17,5 +17,6 @@
 @interface RNSentry : NSObject <RCTBridgeModule, RCTExceptionsManagerDelegate>
 
 + (void)installWithRootView:(RCTRootView *)rootView;
++ (void)installWithBridge:(RCTBridge *)bridge;
 
 @end

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -16,9 +16,13 @@
     return dispatch_get_main_queue();
 }
 
++ (void)installWithBridge:(RCTBridge *)bridge {
+    RNSentry *sentry = [bridge moduleForName:@"RNSentry"];
+    [[bridge moduleForName:@"ExceptionsManager"] initWithDelegate:sentry];
+}
+
 + (void)installWithRootView:(RCTRootView *)rootView {
-    RNSentry *sentry = [rootView.bridge moduleForName:@"RNSentry"];
-    [[rootView.bridge moduleForName:@"ExceptionsManager"] initWithDelegate:sentry];
+    [RNSentry installWithBridge: rootView.bridge];
 }
 
 + (NSNumberFormatter *)numberFormatter {


### PR DESCRIPTION
I am using [react-native-navigation](https://github.com/wix/react-native-navigation) and I want to integrate react-native-sentry to my app. Sadly [I don't know how to access rootView](https://github.com/wix/react-native-navigation/issues/992) with `react-native-navigation`.

Since `installWithRootView` actually uses `RCTBridge` under the hood, I guess adding a `installWithBridge` method should make sense?

Now I can do:

```objective-c
RCTBridge *bridge = [[RCCManager sharedIntance] getBridge];
[RNSentry installWIthBridge: bridge];
```