### PR TITLE
Add out of the box support for Expo

### DIFF
--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -1,7 +1,7 @@
 import {
     NativeModules
 } from 'react-native';
-import Raven from 'raven-js';;
+import Raven from 'raven-js';
 
 const {
     RNSentry

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -96,9 +96,6 @@ export class Sentry {
 
     static setDataCallback(callback) {
       Sentry._ravenClient.setDataCallback(callback);
-      if (Sentry.isNativeClientAvailable()) {
-          console.warn('setDataCallback not supported on native client');
-      }
     }
 
     static setUserContext(user) {

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -94,6 +94,13 @@ export class Sentry {
         if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.nativeCrash();
     }
 
+    static setDataCallback(callback) {
+      Sentry._ravenClient.setDataCallback(callback);
+      if (Sentry.isNativeClientAvailable()) {
+          console.warn('setDataCallback not supported on native client');
+      }
+    }
+
     static setUserContext(user) {
         Sentry._ravenClient.setUserContext(user);
         if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.setUserContext(user);
@@ -265,6 +272,10 @@ class RavenClient {
                 return oldCaptureBreadcrumb.apply(this, arguments);
             }
         }
+    }
+
+    setDataCallback(callback) {
+        Raven.setDataCallback(callback);
     }
 
     setUserContext(user) {

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -73,6 +73,10 @@ export class Sentry {
         Sentry._dsn = dsn;
         Sentry.options = {
             logLevel: SentryLog.None,
+            instrument: {
+              timers: false,
+              eventTargets: false,
+            }
         }
         Object.assign(Sentry.options, options);
         return Sentry;


### PR DESCRIPTION
This resolves various issues that I discussed with Daniel and Armin on Slack. Changes to `lib/Sentry.js` depend on new configuration options which I have PR'd to raven-js.

Wait until https://github.com/getsentry/raven-js/pull/938 lands to merge.