### PR TITLE
Added React to Header Search Paths

### DIFF
--- a/ios/RNSentry.xcodeproj/project.pbxproj
+++ b/ios/RNSentry.xcodeproj/project.pbxproj
@@ -474,7 +474,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNSentry;
@@ -489,7 +492,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				HEADER_SEARCH_PATHS = "$(inherited)";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNSentry;


### PR DESCRIPTION
Added React to the Header Search Paths of `RNSentry.xcodeproj`. This fixes a missing `RCTEventEmitter.h` error as mentioned in https://github.com/getsentry/react-native-sentry/issues/21#issuecomment-300355379