### PR TITLE
Use android buildToolsVersion 23.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
It is recommended by React Native to use build tools 23.0.1

https://facebook.github.io/react-native/releases/0.23/docs/android-setup.html#configure-your-sdk