### PR TITLE
Make Sentry.isNativeClientAvailable a boolean function

### DIFF
--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -85,7 +85,7 @@ export class Sentry {
   }
 
   static isNativeClientAvailable() {
-    return Sentry._nativeClient;
+    return Sentry._nativeClient !== undefined;
   }
 
   static crash() {


### PR DESCRIPTION
## Summary
**Sentry.isNativeClientAvailable()**
Currently, calling this function can throw `undefined`, so we end up writing something like:
```
const isInstalled = Sentry.isNativeClientAvailable() !== undefined;
```

In my opinion, this should return either *true* or *false*. I'd like to get something like this:

```
const isInstalled = Sentry.isNativeClientAvailable();
```

## Use case
In our case, we need to instantiate a shared util that configures Sentry on the go. We need to do this just once, so we ask Sentry if is ready/installed many times, but we set it up just the first one.

**Disclaimer**: not a big JS fan or expert here. And if there is a better way to achieve this behaviour, please let me know!