### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'io.sentry:sentry-android:1.2.1'
+    compile 'io.sentry:sentry-android:1.2.0'
 }


### PR DESCRIPTION
With 1.2.1 version I get "Failed to resolve: io.sentry:sentry-android:1.2.1.
I've search on maven, the lastest version is 1.2.0
This change fix the problem.