### PR TITLE
[Revamped] Allow calls to be made to Sentry when not installed

### DIFF
--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -93,7 +93,7 @@ export class Sentry {
     return Sentry._nativeClient !== undefined;
   }
 
-  static _log(..args) {
+  static _log(...args) {
     console.log.apply(null, args)
   }
 

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -93,6 +93,10 @@ export class Sentry {
     return Sentry._nativeClient !== undefined;
   }
 
+  static _log(..args) {
+    console.log.apply(null, args)
+  }
+
   static crash() {
     throw new Error('Sentry: TEST crash');
   }

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -106,47 +106,57 @@ export class Sentry {
   }
 
   static setDataCallback(callback) {
-    Sentry._ravenClient.setDataCallback(callback);
+    Sentry._log('react-native-sentry (setDataCallback):', callback);
+    if (Sentry._ravenClient) Sentry._ravenClient.setDataCallback(callback);
   }
 
   static setUserContext(user) {
-    Sentry._ravenClient.setUserContext(user);
+    Sentry._log('react-native-sentry (setUserContext):', user);
+    if (Sentry._ravenClient) Sentry._ravenClient.setUserContext(user);
     if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.setUserContext(user);
   }
 
   static setTagsContext(tags) {
-    Sentry._ravenClient.setTagsContext(tags);
+    Sentry._log('react-native-sentry (setTagsContext):', tags);
+    if (Sentry._ravenClient) Sentry._ravenClient.setTagsContext(tags);
     if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.setTagsContext(tags);
   }
 
   static setExtraContext(extra) {
-    Sentry._ravenClient.setExtraContext(extra);
+    Sentry._log('react-native-sentry (setExtraContext):', extra);
+    if (Sentry._ravenClient) Sentry._ravenClient.setExtraContext(extra);
     if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.setExtraContext(extra);
   }
 
   static captureMessage(message, options) {
-    Sentry._ravenClient.captureMessage(message, options);
+    Sentry._log('react-native-sentry (captureMessage):', message, options);
+    if (Sentry._ravenClient) Sentry._ravenClient.captureMessage(message, options);
   }
 
   static captureException(ex, options) {
-    Sentry._ravenClient.captureException(ex, options);
+    Sentry._log('react-native-sentry (captureMessage):', ex, options);
+    if (Sentry._ravenClient) Sentry._ravenClient.captureException(ex, options);
   }
 
   static captureBreadcrumb(msg, options) {
-    Sentry._ravenClient.captureBreadcrumb(msg, options);
+    Sentry._log('react-native-sentry (captureMessage):', msg, options);
+    if (Sentry._ravenClient) Sentry._ravenClient.captureBreadcrumb(msg, options);
   }
 
   static clearContext = async () => {
+    Sentry._log('react-native-sentry (clearContext)');
     if (Sentry.isNativeClientAvailable()) Sentry._nativeClient.clearContext();
-    Sentry._ravenClient.clearContext();
+    if (Sentry._ravenClient) Sentry._ravenClient.clearContext();
   };
 
   static context(options, func, args) {
-    return Sentry._ravenClient.context(options, func, args);
+    Sentry._log('react-native-sentry (context)');
+    if (Sentry._ravenClient) return Sentry._ravenClient.context(options, func, args);
   }
 
   static wrap(options, func, _before) {
-    return Sentry._ravenClient.wrap(options, func, _before);
+    Sentry._log('react-native-sentry (wrap)');
+    if (Sentry._ravenClient) return Sentry._ravenClient.wrap(options, func, _before);
   }
 
   static lastException() {
@@ -160,8 +170,9 @@ export class Sentry {
   }
 
   static setRelease(release) {
+    Sentry._log('react-native-sentry (setRelease)');
     Sentry._setInternalOption('release', release);
-    Sentry._ravenClient.setRelease(release);
+    if (Sentry._ravenClient) Sentry._ravenClient.setRelease(release);
   }
 
   static setDist(dist) {


### PR DESCRIPTION
changed lib/Sentry.js to not require the raven client to be installed following advice from #85. Closes #55.

Previous PR got in a bit of a pickle, so I've opened this one with the relevant commit cherry picked out.

Thanks