### PR TITLE
Bumping sentry-cocoa version to 3.1.2

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 3.0.9'
-  s.dependency 'Sentry/KSCrash', '~> 3.0.9'
+  s.dependency 'Sentry', '~> 3.1.2'
+  s.dependency 'Sentry/KSCrash', '~> 3.1.2'
 
   s.source_files = 'ios/RNSentry*.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'


### PR DESCRIPTION
Currently cocoapods install max version 3.0.12 of `sentry-cocoa`, but in latest version of `react-native-sentry` you are already using latest interface. Especially `shouldSendEvent` callback of `SentryClient`, which has been introduced in version 3.1.0. So we are not able to build it ;) See screenshot below

![screen shot 2017-07-07 at 11 48 36](https://user-images.githubusercontent.com/1526646/27953107-e1718abc-630a-11e7-9c92-fdde77574440.png)
