### PR TITLE
Do not search recursively in glob for ios.

### DIFF
--- a/scripts/postlink
+++ b/scripts/postlink
@@ -407,7 +407,7 @@ function addSentryProperties() {
 Promise.resolve()
   /* these steps patch the build files without user interactions */
   .then(() => patchMatchingFile('**/app/build.gradle', patchBuildGradle))
-  .then(() => patchMatchingFile('**/*.xcodeproj/project.pbxproj', patchXcodeProj))
+  .then(() => patchMatchingFile('*/*.xcodeproj/project.pbxproj', patchXcodeProj))
   .then(() => patchMatchingFile('**/AppDelegate.m', patchAppDelegate))
   /* if any of the previous steps did something, this will patch
      the index.PLATFORM.js files with the necessary initialization code */


### PR DESCRIPTION
This issue has been brought up before, there is an ignore list for the glob `['node_modules/**', 'ios/Pods/**', '**/Pods/**']` however I have a git submodule within my project hence this does not get ignored. So changed it such that the glob only searches 1 directory down for the `*.xcodeproj/project.pbxproj` file.