### PR TITLE
Remove 'app://' prefix

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -334,7 +334,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             String lastPathComponent = lastFileNameSegments[0];
             String[] fileNameSegments = lastPathComponent.split("/");
             String calculatedFileName = fileNameSegments[fileNameSegments.length-1];
-            StringBuilder finalFileName = new StringBuilder("app:///").append(calculatedFileName);
+            StringBuilder finalFileName = new StringBuilder("/").append(calculatedFileName);
 
             // We want to skip native code frames without function
             if (methodName.equals("?") && calculatedFileName.equals("[native code]")) {

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -117,7 +117,7 @@ NSArray *SentryParseRavenFrames(NSArray *ravenFrames) {
         }
         NSString *simpleFilename = [[[frame[@"file"] lastPathComponent] componentsSeparatedByString:@"?"] firstObject];
         SentryFrame *sentryFrame = [[SentryFrame alloc] init];
-        sentryFrame.fileName = [NSString stringWithFormat:@"app:///%@", simpleFilename];
+        sentryFrame.fileName = [NSString stringWithFormat:@"/%@", simpleFilename];
         sentryFrame.function = frame[@"methodName"];
         sentryFrame.lineNumber = frame[@"lineNumber"];
         sentryFrame.columnNumber = frame[@"column"];

--- a/lib/raven-plugin.js
+++ b/lib/raven-plugin.js
@@ -42,7 +42,7 @@ var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
  * Strip device-specific IDs from React Native file:// paths
  */
 function normalizeUrl(url, pathStripRe) {
-  return url.replace(/^file\:\/\//, 'app://').replace(pathStripRe, '');
+  return url.replace(/^file\:\/\//, '').replace(pathStripRe, '');
 }
 
 /**


### PR DESCRIPTION
This was causing issues because we could not upload sourcemaps with
slashes in the filename (or in the prefix).