### PR TITLE
Fixed Compilation Error in React Native 0.47.0

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryPackage.java
+++ b/android/src/main/java/io/sentry/RNSentryPackage.java
@@ -29,7 +29,6 @@ public class RNSentryPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNSentryModule(reactContext, this.getReactApplication()), new RNSentryEventEmitter(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModules was removed in 0.47.0 release here https://github.com/facebook/react-native/releases/tag/v0.47.0
RN code change here https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

I only remove @Override keyword, not sure if keeping the function would make it compatible with older versions of RN. Please check.