### PR TITLE
Fix gradle script getResDir for gradle > 3.0

### DIFF
--- a/appium/Makefile
+++ b/appium/Makefile
@@ -15,7 +15,9 @@ copy-local-files-to-example:
 	rm -rf example/node_modules/react-native-sentry/ios/Sentry/Sources/Sentry/*
 	rm -rf example/node_modules/react-native-sentry/android/*
 	rm -rf example/node_modules/react-native-sentry/scripts/*
+	rm -rf example/node_modules/react-native-sentry/sentry.gradle
 	cp -r ../lib/* example/node_modules/react-native-sentry/lib/
+	cp ../sentry.gradle example/node_modules/react-native-sentry/sentry.gradle
 	cp -r ../scripts/* example/node_modules/react-native-sentry/scripts/
 	find ../ios -name 'RN*.[h|m]' -exec cp {} example/node_modules/react-native-sentry/ios/ \;
 	cp -r ../android/* example/node_modules/react-native-sentry/android/

--- a/appium/fastlane/Fastfile
+++ b/appium/fastlane/Fastfile
@@ -3,16 +3,16 @@ fastlane_version "2.48.0"
 default_platform :ios
 
 def validate_android_build_output(output)
-  UI.user_error!("Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.full-1.0-full\/files\//).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.demo-1.0-demo\/files\//).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle"/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle"/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle.map"/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle.map"/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle$/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle.map$/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle$/).size >1
-  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle.map$/).size >1
+  UI.user_error!("1 Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.full-1.0-full\/files\//).size >1
+  UI.user_error!("2 Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.demo-1.0-demo\/files\//).size >1
+  UI.user_error!("3 Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle"/).size >1
+  UI.user_error!("4 Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle"/).size >1
+  UI.user_error!("5 Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle.map"/).size >1
+  UI.user_error!("6 Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle.map"/).size >1
+  UI.user_error!("7 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle$/).size >1
+  UI.user_error!("8 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle.map$/).size >1
+  UI.user_error!("9 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle$/).size >1
+  UI.user_error!("10 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle.map$/).size >1
   UI.success("Android build output validated")
 end
 

--- a/appium/fastlane/Fastfile
+++ b/appium/fastlane/Fastfile
@@ -2,6 +2,20 @@ fastlane_version "2.48.0"
 
 default_platform :ios
 
+def validate_android_build_output(output)
+  UI.user_error!("Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.full-1.0-full\/files\//).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/POST \/api\/0\/projects\/sentry-test\/react-native\/releases\/com.awesomeproject.demo-1.0-demo\/files\//).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle"/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle"/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle.map"/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle.map"/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle$/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle.map$/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle$/).size >1
+  UI.user_error!("Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle.map$/).size >1
+  UI.success("Android build output validated")
+end
+
 platform :ios do
   before_all do
     # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
@@ -54,14 +68,15 @@ platform :ios do
   end
 
   lane :build_android_for_device_farm do
-    sh("cd ../example/android/; ./gradlew assembleRelease --stacktrace")
-    sh("jarsigner -verbose  -digestalg SHA1 -sigalg MD5withRSA -keystore release.keystore -storepass 123456 ../example/android/app/build/outputs/apk/app-release-unsigned.apk release")
+    android_build_output = sh("cd ../example/android/; ./gradlew -Psentryloglevel=debug assembleRelease --stacktrace")
+    validate_android_build_output(android_build_output)
+    sh("jarsigner -verbose  -digestalg SHA1 -sigalg MD5withRSA -keystore release.keystore -storepass 123456 ../example/android/app/build/outputs/apk/app-full-release-unsigned.apk release")
   end
 
   lane :aws_android_upload_and_run do
     aws_device_farm(
       name: "react-native",
-      binary_path: "example/android/app/build/outputs/apk/app-release-unsigned.apk",
+      binary_path: "example/android/app/build/outputs/apk/app-full-release-unsigned.apk",
       device_pool: "Android",
       test_binary_path: "test_bundle.zip",
       test_package_type: "APPIUM_PYTHON_TEST_PACKAGE",

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -58,14 +58,22 @@ gradle.projectsEvaluated {
 
                 workingDir reactRoot
                 environment("SENTRY_PROPERTIES", propertiesFile)
+
                 def args = [
-                    cliExecutable,
-                    "react-native",
-                    "gradle",
-                    "--bundle", bundleOutput,
-                    "--sourcemap", sourcemapOutput,
-                    "--release", releaseName
+                    cliExecutable
                 ];
+                if (project.hasProperty("sentryloglevel") ) {
+                    args.push("--log-level");
+                    args.push(sentryloglevel);
+                }
+                args.push("react-native");
+                args.push("gradle");
+                args.push("--bundle");
+                args.push(bundleOutput);
+                args.push("--sourcemap");
+                args.push(sourcemapOutput);
+                args.push("--release");
+                args.push(releaseName);
 
                 versionCodes.each { versionCode ->
                     args.add("--dist");

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -1,23 +1,13 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
 gradle.projectsEvaluated {
-    // to find out which releases are being generated we hook into the process
-    // resources task.  From the "assetsDir" property we can extract in which
-    // assets folder the task is operating.  This folder matches where react native
-    // will place the bundles.
-    def releasesForFolder = [:];
+    def releases = [];
     android.applicationVariants.each { variant ->
         def releaseName = "${variant.getApplicationId()}-${variant.getVersionName()}";
         variant.outputs.each { output ->
             def processTask = output.getProcessResources();
-            def resDir = processTask.getResDir();
-            def releases = releasesForFolder.get(resDir.toString()) as List<String>;
-            if (releases == null) {
-                releases = [];
-                releasesForFolder.put(resDir.toString(), releases);
-            }
             def versionCode = output.getVersionCode();
-            releases.add([releaseName, versionCode]);
+            releases.add([output.getName(), releaseName, versionCode]);
         }
     }
 
@@ -28,27 +18,6 @@ gradle.projectsEvaluated {
         task.name.startsWith("bundle") && task.name.endsWith("JsAndAssets")
     }
     bundleTasks.each { bundleTask ->
-        def outputs = bundleTask.getOutputs();
-        def allReleases = [:];
-        outputs.getFiles().each { file ->
-            def releases = releasesForFolder.get(file.toString());
-            if (releases != null) {
-                releases.each { item ->
-                    def codes = allReleases[item[0]] as List<String>;
-                    if (codes == null) {
-                        codes = [];
-                        allReleases[item[0]] = codes;
-                    }
-                    codes.add(item[1]);
-                }
-            }
-        }
-
-        // this really should not happen but better be safe than sorry.
-        if (allReleases.size() == 0) {
-            return;
-        }
-
         def props = bundleTask.getProperties();
         def cmd = props.get("commandLine") as List<String>;
         def cmdArgs = props.get("args") as List<String>;
@@ -81,9 +50,9 @@ gradle.projectsEvaluated {
         bundleTask.setProperty("commandLine", cmd);
         bundleTask.setProperty("args", cmdArgs);
 
-        allReleases.each { releaseName, versionCodes ->
+        releases.each { variant, releaseName, versionCodes ->
             def cliTask = tasks.create(
-                name: bundleTask.getName() + "SentryUpload",
+                name: bundleTask.getName() + variant + "SentryUpload",
                 type: Exec) {
                 description = "upload debug symbols to sentry"
 


### PR DESCRIPTION
This PR fixes gradle plugin error `getResDir`
The output of `./gradlew assembleRelease --stacktrace` is: (so it seems to work)
```
...
:app:bundleReleaseJsAndAssets
Scanning 564 folders for symlinks in /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/node_modules (8ms)
Scanning 564 folders for symlinks in /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/node_modules (17ms)
Loading dependency graph, done.
warning: the transform cache was reset.
bundle: start
bundle: finish
bundle: Writing bundle output to: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/app/build/intermediates/assets/release/index.android.bundle
bundle: Writing sourcemap output to: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/app/build/intermediates/assets/release/index.android.bundle.map
bundle: Done writing bundle output
bundle: Done writing sourcemap output
Processing react-native sourcemaps for Sentry upload.
> Analyzing 2 sources
> Rewriting sources
> Adding source map references
Uploading sourcemaps for release com.awesomeproject-1.0 distribution 1
> Uploading source maps for release com.awesomeproject-1.0

Source Map Upload Report
  Minified Scripts
    ~/index.android.bundle (sourcemap at index.android.bundle.map)
  Source Maps
    ~/index.android.bundle.map
Processing react-native sourcemaps for Sentry upload.
> Analyzing 2 sources
> Rewriting sources
> Adding source map references
Uploading sourcemaps for release com.awesomeproject-1.0 distribution 1
> Uploading source maps for release com.awesomeproject-1.0

Source Map Upload Report
  Minified Scripts
    ~/index.android.bundle (sourcemap at index.android.bundle.map)
  Source Maps
    ~/index.android.bundle.map
:app:processReleaseManifest
:app:processReleaseResources
...
```