### PR TITLE
Add functionality for flavor aware sentry properties in gradle

### DIFF
--- a/appium/fastlane/Fastfile
+++ b/appium/fastlane/Fastfile
@@ -68,7 +68,7 @@ platform :ios do
   end
 
   lane :build_android_for_device_farm do
-    android_build_output = sh("cd ../example/android/; ./gradlew -Psentryloglevel=debug assembleRelease --stacktrace")
+    android_build_output = sh("cd ../example/android/; ./gradlew assembleRelease --stacktrace")
     validate_android_build_output(android_build_output)
     sh("jarsigner -verbose  -digestalg SHA1 -sigalg MD5withRSA -keystore release.keystore -storepass 123456 ../example/android/app/build/outputs/apk/app-full-release-unsigned.apk release")
   end

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -1,5 +1,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 
+def config = project.hasProperty("sentry") ? project.sentry : [];
+
 gradle.projectsEvaluated {
     def releases = [];
     android.applicationVariants.each { variant ->
@@ -44,7 +46,7 @@ gradle.projectsEvaluated {
         bundleTask.setProperty("commandLine", cmd);
         bundleTask.setProperty("args", cmdArgs);
 
-        if (project.hasProperty("flavoraware")) {
+        if (config.flavorAware) {
             println "**********************************"
             println "* Flavor aware sentry properties *"
             println "**********************************"
@@ -57,7 +59,7 @@ gradle.projectsEvaluated {
                 description = "upload debug symbols to sentry"
 
                 def propertiesFile = "$reactRoot/android/sentry.properties";
-                if (project.hasProperty("flavoraware")) {
+                if (config.flavorAware) {
                     propertiesFile = "$reactRoot/android/sentry-$variant"+".properties"
                     println "For $variant using: $propertiesFile"
                 } else {
@@ -76,12 +78,12 @@ gradle.projectsEvaluated {
                 def args = [
                     cliExecutable
                 ];
-                if (project.hasProperty("sentryloglevel")) {
+                if (config.logLevel) {
                     args.push("--log-level");
-                    args.push(sentryloglevel);
+                    args.push(config.logLevel);
                 }
 
-                if (project.hasProperty("flavoraware")) {
+                if (config.flavorAware) {
                     args.push("--url");
                     args.push(sentryProps.get("defaults.url"));
                     args.push("--auth-token");
@@ -97,7 +99,7 @@ gradle.projectsEvaluated {
                 args.push("--release");
                 args.push(releaseName);
 
-                if (project.hasProperty("flavoraware")) {
+                if (config.flavorAware) {
                     args.push("--org");
                     args.push(sentryProps.get("defaults.org"));
                     args.push("--project");
@@ -109,7 +111,7 @@ gradle.projectsEvaluated {
                     args.add(versionCode);
                 }
 
-                if (project.hasProperty("sentryloglevel")) {
+                if (config.logLevel) {
                     println args
                 }
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -24,12 +24,6 @@ gradle.projectsEvaluated {
         def bundleOutput = null;
         def sourcemapOutput = null;
         def reactRoot = props.get("workingDir");
-        def propertiesFile = "$reactRoot/android/sentry.properties";
-        Properties sentryProps = new Properties();
-        try {
-            sentryProps.load(new FileInputStream(propertiesFile));
-        } catch (FileNotFoundException e) {}
-        def cliExecutable = sentryProps.get("cli.executable", "$reactRoot/node_modules/sentry-cli-binary/bin/sentry-cli");
 
         cmdArgs.eachWithIndex{ String arg, int i ->
             if (arg == "--bundle-output") {
@@ -50,11 +44,28 @@ gradle.projectsEvaluated {
         bundleTask.setProperty("commandLine", cmd);
         bundleTask.setProperty("args", cmdArgs);
 
+        if (project.hasProperty("flavoraware")) {
+            println "********************************"
+            println "*Flavor aware sentry properties*"
+            println "********************************"
+        }
+
         releases.each { variant, releaseName, versionCodes ->
             def cliTask = tasks.create(
                 name: bundleTask.getName() + variant + "SentryUpload",
                 type: Exec) {
                 description = "upload debug symbols to sentry"
+
+                def propertiesFile = "$reactRoot/android/sentry.properties";
+                if (project.hasProperty("flavoraware")) {
+                    propertiesFile = "$reactRoot/android/sentry-$variant"+".properties"
+                    println "For $variant using: $propertiesFile"
+                }
+                Properties sentryProps = new Properties();
+                try {
+                    sentryProps.load(new FileInputStream(propertiesFile));
+                } catch (FileNotFoundException e) {}
+                def cliExecutable = sentryProps.get("cli.executable", "$reactRoot/node_modules/sentry-cli-binary/bin/sentry-cli");
 
                 workingDir reactRoot
                 environment("SENTRY_PROPERTIES", propertiesFile)
@@ -62,7 +73,7 @@ gradle.projectsEvaluated {
                 def args = [
                     cliExecutable
                 ];
-                if (project.hasProperty("sentryloglevel") ) {
+                if (project.hasProperty("sentryloglevel")) {
                     args.push("--log-level");
                     args.push(sentryloglevel);
                 }

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -45,9 +45,9 @@ gradle.projectsEvaluated {
         bundleTask.setProperty("args", cmdArgs);
 
         if (project.hasProperty("flavoraware")) {
-            println "********************************"
-            println "*Flavor aware sentry properties*"
-            println "********************************"
+            println "**********************************"
+            println "* Flavor aware sentry properties *"
+            println "**********************************"
         }
 
         releases.each { variant, releaseName, versionCodes ->
@@ -60,15 +60,18 @@ gradle.projectsEvaluated {
                 if (project.hasProperty("flavoraware")) {
                     propertiesFile = "$reactRoot/android/sentry-$variant"+".properties"
                     println "For $variant using: $propertiesFile"
+                } else {
+                    environment("SENTRY_PROPERTIES", propertiesFile)
                 }
                 Properties sentryProps = new Properties();
                 try {
                     sentryProps.load(new FileInputStream(propertiesFile));
-                } catch (FileNotFoundException e) {}
+                } catch (FileNotFoundException e) {
+                    println "File not found: $propertiesFile"
+                }
                 def cliExecutable = sentryProps.get("cli.executable", "$reactRoot/node_modules/sentry-cli-binary/bin/sentry-cli");
 
                 workingDir reactRoot
-                environment("SENTRY_PROPERTIES", propertiesFile)
 
                 def args = [
                     cliExecutable
@@ -77,6 +80,14 @@ gradle.projectsEvaluated {
                     args.push("--log-level");
                     args.push(sentryloglevel);
                 }
+
+                if (project.hasProperty("flavoraware")) {
+                    args.push("--url");
+                    args.push(sentryProps.get("defaults.url"));
+                    args.push("--auth-token");
+                    args.push(sentryProps.get("auth.token"));
+                }
+
                 args.push("react-native");
                 args.push("gradle");
                 args.push("--bundle");
@@ -86,11 +97,21 @@ gradle.projectsEvaluated {
                 args.push("--release");
                 args.push(releaseName);
 
+                if (project.hasProperty("flavoraware")) {
+                    args.push("--org");
+                    args.push(sentryProps.get("defaults.org"));
+                    args.push("--project");
+                    args.push(sentryProps.get("defaults.project"));
+                }
+
                 versionCodes.each { versionCode ->
                     args.add("--dist");
                     args.add(versionCode);
                 }
 
+                if (project.hasProperty("sentryloglevel")) {
+                    println args
+                }
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine("cmd", "/c", *args)
                 } else {


### PR DESCRIPTION
Fixes https://github.com/getsentry/react-native-sentry/issues/157

~~If you pass `-Pflavoraware=true` to gradle e.g.:~~

~~`./gradlew -Pflavoraware=true assembleDebug --stacktrace`~~

it produces the following output and uses `url` `authtoken` `org` `project` from the file to pass it to `sentry-cli`.

```
**********************************
* Flavor aware sentry properties *
**********************************
For demoDebug using: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/sentry-demoDebug.properties
For demoRelease using: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/sentry-demoRelease.properties
For fullDebug using: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/sentry-fullDebug.properties
For fullRelease using: /Users/haza/Projects/react-native-sentry/examples/react-native/AwesomeProject/android/sentry-fullRelease.properties
```