### PR TITLE
Improve performance on stacktrace merging

### DIFF
--- a/ios/RNSentryEventEmitter.h
+++ b/ios/RNSentryEventEmitter.h
@@ -12,5 +12,6 @@
 @interface RNSentryEventEmitter : RCTEventEmitter <RCTBridgeModule>
 
 + (void)emitStoredEvent;
++ (void)emitModuleTableUpdate:(NSDictionary *)moduleTable;
 
 @end

--- a/ios/RNSentryEventEmitter.m
+++ b/ios/RNSentryEventEmitter.m
@@ -10,6 +10,7 @@
 
 NSString *const kEventSentSuccessfully = @"Sentry/eventSentSuccessfully";
 NSString *const kEventStored = @"Sentry/eventStored";
+NSString *const kModuleTable = @"Sentry/moduleTable";
 
 @implementation RNSentryEventEmitter
 
@@ -18,12 +19,13 @@ RCT_EXPORT_MODULE();
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {
     return @{
              @"EVENT_SENT_SUCCESSFULLY": kEventSentSuccessfully,
-             @"EVENT_STORED": kEventStored
+             @"EVENT_STORED": kEventStored,
+             @"MODULE_TABLE": kModuleTable
              };
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[kEventSentSuccessfully, kEventStored];
+    return @[kEventSentSuccessfully, kEventStored, kModuleTable];
 }
 
 
@@ -42,6 +44,13 @@ RCT_EXPORT_MODULE();
 
 + (void)emitStoredEvent {
     [self postNotificationName:kEventStored withPayload:@""];
+}
+
++ (void)emitModuleTableUpdate:(NSDictionary *)moduleTable {
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:moduleTable
+                                                       options:0
+                                                         error:nil];
+    [self postNotificationName:kModuleTable withPayload:[[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]];
 }
 
 + (void)postNotificationName:(NSString *)name withPayload:(NSObject *)object {

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -1,5 +1,5 @@
-import {NativeModules} from 'react-native';
-const {RNSentry} = NativeModules;
+import {NativeModules, NativeEventEmitter} from 'react-native';
+const {RNSentry, RNSentryEventEmitter} = NativeModules;
 
 const DEFAULT_MODULE_IGNORES = [
   'AccessibilityManager',
@@ -58,6 +58,10 @@ export class NativeClient {
     RNSentry.startWithDsnString(this._dsn);
     if (this.options.deactivateStacktraceMerging === false) {
       this._activateStacktraceMerging();
+      const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
+      eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
+        this._updateIgnoredModules(JSON.parse(moduleTable.payload));
+      });
     }
     RNSentry.setLogLevel(options.logLevel);
   }
@@ -92,6 +96,25 @@ export class NativeClient {
 
   clearContext() {
     RNSentry.clearContext();
+  }
+
+  _updateIgnoredModules(modules) {
+    const values = Object.values(modules);
+    const keys = Object.keys(modules);
+    for (let i = 0; i < values.length; i++) {
+      const moduleName = values[i].replace(/RCT/, '');
+      const moduleID = keys[i];
+      if (this._ignoredModules[moduleID]) {
+        continue;
+      }
+      if (
+        this.options.ignoreModulesExclude.indexOf(moduleName) === -1 &&
+        (DEFAULT_MODULE_IGNORES.indexOf(moduleName) >= 0 ||
+          this.options.ignoreModulesInclude.indexOf(moduleName) >= 0)
+      ) {
+        this._ignoredModules[moduleID] = true;
+      }
+    }
   }
 
   _activateStacktraceMerging = async () => {
@@ -152,7 +175,8 @@ export class NativeClient {
         return original.apply(this, arguments);
       }
       params.push({
-        __sentry_stack: new Error().stack
+        __sentry_stack: new Error().stack,
+        __sentry_moduleID: moduleID
       });
       return original.apply(this, arguments);
     };

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -107,13 +107,17 @@ export class NativeClient {
       if (this._ignoredModules[moduleID]) {
         continue;
       }
-      if (
-        this.options.ignoreModulesExclude.indexOf(moduleName) === -1 &&
-        (DEFAULT_MODULE_IGNORES.indexOf(moduleName) >= 0 ||
-          this.options.ignoreModulesInclude.indexOf(moduleName) >= 0)
-      ) {
-        this._ignoredModules[moduleID] = true;
-      }
+      this._addIgnoredModule(moduleID, moduleName);
+    }
+  }
+
+  _addIgnoredModule(moduleID, moduleName) {
+    if (
+      this.options.ignoreModulesExclude.indexOf(moduleName) === -1 &&
+      (DEFAULT_MODULE_IGNORES.indexOf(moduleName) >= 0 ||
+        this.options.ignoreModulesInclude.indexOf(moduleName) >= 0)
+    ) {
+      this._ignoredModules[moduleID] = true;
     }
   }
 
@@ -128,26 +132,15 @@ export class NativeClient {
         if (typeof __fbBatchedBridgeConfig !== 'undefined') {
           /* global __fbBatchedBridgeConfig */
           __fbBatchedBridgeConfig.remoteModuleConfig.forEach((module, moduleID) => {
-            if (
-              module !== null &&
-              this.options.ignoreModulesExclude.indexOf(module[0]) === -1 &&
-              (DEFAULT_MODULE_IGNORES.indexOf(module[0]) >= 0 ||
-                this.options.ignoreModulesInclude.indexOf(module[0]) >= 0)
-            ) {
-              this._ignoredModules[moduleID] = true;
+            if (module !== null) {
+              this._addIgnoredModule(moduleID, module[0]);
             }
           });
         } else if (BatchedBridge._remoteModuleTable) {
-          for (let module in BatchedBridge._remoteModuleTable) {
-            if (BatchedBridge._remoteModuleTable.hasOwnProperty(module)) {
-              let moduleName = BatchedBridge._remoteModuleTable[module];
-              if (
-                this.options.ignoreModulesExclude.indexOf(moduleName) === -1 &&
-                (DEFAULT_MODULE_IGNORES.indexOf(moduleName) >= 0 ||
-                  this.options.ignoreModulesInclude.indexOf(moduleName) >= 0)
-              ) {
-                this._ignoredModules[module] = true;
-              }
+          for (let moduleID in BatchedBridge._remoteModuleTable) {
+            if (BatchedBridge._remoteModuleTable.hasOwnProperty(moduleID)) {
+              let moduleName = BatchedBridge._remoteModuleTable[moduleID];
+              this._addIgnoredModule(moduleID, moduleName);
             }
           }
         }


### PR DESCRIPTION
Fixes #158 

For react-native > 0.45 they no longer provide the `moduleID` <-> `moduleName` mapping we use to not trace every stacktrace that crosses the native bridge.
This result is a massive performance impact when for example an animation happens and react-native sends an update over the native bridge for every frame (almost 60 updates / sec) which is way to much when we always create a `new Error().stack`.

This PR adds a workaround; We are able to fetch the `moduleName` on the native side, I additionally send the `moduleID` over the bridge and build an index on native with `moduleID` <-> `moduleName`.
After an update to this, I propagate the changes to javascript (EventEmitter) and build our `_ignoredModules` in javascript which we then use to decide what we send over the native bridge. 
The result of this is that we build the ignore index on the fly which improves performance greatly.