### PR TITLE
Upgrade sentry-android depdendency to 1.5.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'io.sentry:sentry-android:1.5.1'
+    compile 'io.sentry:sentry-android:1.5.3'
 }


### PR DESCRIPTION
I realized this did actually fix a bug that is possible on Android, may as well bump it.