### PR TITLE
fix: url for frames when using raven-js

### DIFF
--- a/lib/raven-plugin.js
+++ b/lib/raven-plugin.js
@@ -255,7 +255,9 @@ reactNativePlugin._normalizeData = function(data, pathStripRe) {
     data.stacktrace || (data.exception && data.exception.values[0].stacktrace);
   if (stacktrace) {
     stacktrace.frames.forEach(function(frame) {
-      frame.filename = normalizeUrl(frame.filename, pathStripRe);
+      if (frame.filename !== '[native code]') {
+        frame.filename = normalizeUrl(frame.filename, pathStripRe);
+      }
     });
   }
   return data;

--- a/lib/raven-plugin.js
+++ b/lib/raven-plugin.js
@@ -35,7 +35,7 @@ function wrappedCallback(callback) {
 // Example React Native path format (iOS):
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
-var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
+var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush|.*(?=\/))/;
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
 
@@ -43,7 +43,7 @@ var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
  * Strip device-specific IDs from React Native file:// paths
  */
 function normalizeUrl(url, pathStripRe) {
-  return url.replace(/^file\:\/\//, 'app://').replace(pathStripRe, '');
+  return 'app://' + url.replace(/^file\:\/\//, '').replace(pathStripRe, '');
 }
 
 /**


### PR DESCRIPTION
This PR fixes bad frame paths when only using `raven-js` aka `disableNativeIntegration`
ref: https://forum.sentry.io/t/react-native-sentry-android-sourcemaps-uploaded-but-not-matched/2377/7

Also, it updates the regex to work with CodePush 
ref: https://github.com/getsentry/raven-js/pull/1042