### PR TITLE
Use export * to export items in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
 'use strict';
-import * as sentry from './lib/Sentry';
-module.exports = sentry;
+export * from './lib/Sentry';


### PR DESCRIPTION
eslint-plugin-import doesn't track the exports properly when passed through
indirectly, and this approach is more direct / succinct.