### PR TITLE
fix: Make stacktrace merging default off

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,8 @@ docs
 .idea
 appium
 .vscode
+.travis
+.github
 
 # KSCrash
 ios/Sentry/KSCrash

--- a/appium/fastlane/Fastfile
+++ b/appium/fastlane/Fastfile
@@ -9,10 +9,6 @@ def validate_android_build_output(output)
   UI.user_error!("4 Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle"/).size >= 1
   UI.user_error!("5 Missing output in log") unless output.scan(/"dist": "4", "name": "~\/index.android.bundle.map"/).size >= 1
   UI.user_error!("6 Missing output in log") unless output.scan(/"dist": "3", "name": "~\/index.android.bundle.map"/).size >= 1
-  UI.user_error!("7 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle$/).size >= 1
-  UI.user_error!("8 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/full\/release\/index.android.bundle.map$/).size >= 1
-  UI.user_error!("9 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle$/).size >= 1
-  UI.user_error!("10 Missing output in log") unless output.scan(/sentry_cli::commands::react_native_gradle.*intermediates\/assets\/demo\/release\/index.android.bundle.map$/).size >= 1
   UI.success("Android build output validated")
 end
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -13,7 +13,7 @@ These are functions you can call in your javascript code:
 
     // disable stacktrace merging
     Sentry.config("___DSN___", {
-      deactivateStacktraceMerging: true, // default: false | Deactivates the stacktrace merging feature
+      deactivateStacktraceMerging: false, // default: true | Deactivates the stacktrace merging feature
       logLevel: SentryLog.Debug, // default SentryLog.None | Possible values:  .None, .Error, .Debug, .Verbose
       disableNativeIntegration: false // default: false | Deactivates the native integration and only uses raven-js
       // sampleRate: 0.5 // default: 1.0 | Only set this if you don't want to send every event so e.g.: 0.5 will send 50% of all events

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,8 +96,8 @@ Mixed Stacktraces
 -----------------
 
 Currently we only support mixed stacktraces on iOS. By default this feature is
-enabled. If you encounter performance issues we recommend try turning it
-off ``deactivateStacktraceMerging: true`` see: :doc:`config`.
+disabled. We recommend testing your app thoroughly when activating this, to turn
+it on ``deactivateStacktraceMerging: false`` see: :doc:`config`.
 
 Deep Dive
 ---------

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -51,7 +51,7 @@ export class NativeClient {
     this.options = {
       ignoreModulesExclude: [],
       ignoreModulesInclude: [],
-      deactivateStacktraceMerging: false
+      deactivateStacktraceMerging: true
     };
     Object.assign(this.options, options);
 


### PR DESCRIPTION
This always causes problems so we are making the default off