### PR TITLE
feat: Update link step to use new App.js for rn > 0.49

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
     },
     "android": {
       "packageInstance": "new RNSentryPackage(MainApplication.this)"
+    },
+    "ios": {
+      "sharedLibraries": [
+        "libz"
+      ]
     }
   },
   "devDependencies": {

--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -360,6 +360,14 @@ function addNewXcodeBuildPhaseForSymbols(buildScripts, proj) {
   );
 }
 
+function addZLibToXcode(proj) {
+  proj.addPbxGroup([], 'Frameworks', 'Application');
+  proj.addFramework('libz.tbd', {
+    link: true,
+    target: proj.getFirstTarget().uuid
+  });
+}
+
 function patchXcodeProj(contents, filename) {
   let proj = xcode.project(filename);
   return new Promise(function(resolve, reject) {
@@ -379,6 +387,7 @@ function patchXcodeProj(contents, filename) {
 
       patchExistingXcodeBuildScripts(buildScripts);
       addNewXcodeBuildPhaseForSymbols(buildScripts, proj);
+      addZLibToXcode(proj);
 
       // we always modify the xcode file in memory but we only want to save it
       // in case the user wants configuration for ios.  This is why we check


### PR DESCRIPTION
Bump sentry-cocoa version
Note:
https://github.com/getsentry/react-native-sentry/pull/265/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R40
This is supported for over a year now, so we should be good.