### PR TITLE
Bump sentry-android to 1.6.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'io.sentry:sentry-android:1.5.3'
+    compile 'io.sentry:sentry-android:1.6.1'
 }


### PR DESCRIPTION
Multiple bugfixes, but one effects offline disk buffering of events so probably useful here.