### PR TITLE
ci: Prevent device farm builds in outside PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
           - addon-google_apis-google-16
       env: LANE='android'
       script: .travis/run.sh
+      if: env(TRAVIS_SECURE_ENV_VARS) = true
 
     - language: objective-c
       os: osx
@@ -50,6 +51,7 @@ matrix:
         - virtualenv ~/virtualenv
         - source ~/virtualenv/bin/activate
       script: .travis/run.sh
+      if: env(TRAVIS_SECURE_ENV_VARS) = true
 
     - language: node_js
       node_js: 8


### PR DESCRIPTION
Device farm tests cannot be executed in PRs from contributors outside of the
organization since secure environment variables are missing. Besides that,
they take awfully long to execute and force contributors to wait unnecessarily.
An example of this is #266.

This fix follows an approach from getsentry/raven-js#1095, by using the
`TRAVIS_SECURE_ENV_VARS` variable. It indicates whenever the variables are
present.