### PR TITLE
fix: Call store event on android when the event has been sent

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 3.9.0'
-  s.dependency 'Sentry/KSCrash', '~> 3.9.0'
+  s.dependency 'Sentry', '~> 3.10.0'
+  s.dependency 'Sentry/KSCrash', '~> 3.10.0'
 
   s.source_files = 'ios/RNSentry*.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -118,6 +118,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                     ExceptionInterface exceptionInterface = ((ExceptionInterface)event.getSentryInterfaces().get(ExceptionInterface.EXCEPTION_INTERFACE));
                     params.putString("message", exceptionInterface.getExceptions().getFirst().getExceptionMessage());
                 }
+                RNSentryEventEmitter.sendEvent(reactContext, RNSentryEventEmitter.SENTRY_EVENT_STORED, new WritableNativeMap());
                 RNSentryEventEmitter.sendEvent(reactContext, RNSentryEventEmitter.SENTRY_EVENT_SENT_SUCCESSFULLY, params);
             }
         });
@@ -252,7 +253,6 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
         }
 
         Sentry.capture(buildEvent(eventBuilder));
-        RNSentryEventEmitter.sendEvent(reactContext, RNSentryEventEmitter.SENTRY_EVENT_STORED, new WritableNativeMap());
     }
 
     @ReactMethod


### PR DESCRIPTION
Fixes: https://github.com/getsentry/react-native-sentry/issues/169

This fix is more of a workaround, the problem probably was that it created some kind of race condition where the sending of the event isn't fully done yet, but the bubbling of the JS error from react-native causing a crash was interrupting the send process.
So it sometimes happened that the event still was sent, but then also stored and send again after restart.
Now on Android I send the notification of storing the event after I receive the success callback of sending it.
That makes sure that it has been send before the app crashes.
On iOS we only really store the event and not try to send it at all.