### PR TITLE
Bump native iOS Sentry dependency

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 3.9.0'
-  s.dependency 'Sentry/KSCrash', '~> 3.9.0'
+  s.dependency 'Sentry', '~> 3.10.0'
+  s.dependency 'Sentry/KSCrash', '~> 3.10.0'
 
   s.source_files = 'ios/RNSentry*.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'


### PR DESCRIPTION
Includes a security update https://github.com/getsentry/sentry-cocoa/releases/tag/3.10.0