### PR TITLE
Expose crashedLastLaunch for iOS

### DIFF
--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -16,6 +16,8 @@ NSString *const RNSentrySdkName = @"sentry-react-native";
 
 @property (nonatomic, strong) NSMutableDictionary *moduleMapping;
 
+@property (nonatomic, strong) SentryClient *client;
+
 @end
 
 
@@ -116,11 +118,22 @@ RCT_EXPORT_MODULE()
     return @{@"nativeClientAvailable": @YES};
 }
 
+RCT_EXPORT_METHOD(crashedLastLaunch:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSNumber *crashedLastLaunch = @NO;
+
+    if ([self.client crashedLastLaunch]) {
+        crashedLastLaunch = @YES;
+    }
+    resolve(crashedLastLaunch);
+}
+
 RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString options:(NSDictionary *_Nonnull)options)
 {
     NSError *error = nil;
     self.moduleMapping = [[NSMutableDictionary alloc] init];
     SentryClient *client = [[SentryClient alloc] initWithDsn:dsnString didFailWithError:&error];
+    self.client = client;
     client.beforeSerializeEvent = ^(SentryEvent * _Nonnull event) {
         [self injectReactNativeFrames:event];
         [self setReleaseVersionDist:event];

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -138,6 +138,10 @@ export const Sentry = {
     if (Sentry._ravenClient) Sentry._ravenClient.clearContext();
   },
 
+  async crashedLastLaunch() {
+    return await RNSentry.crashedLastLaunch();
+  },
+
   context(options, func, args) {
     Sentry._log('react-native-sentry (context)');
     if (Sentry._ravenClient) return Sentry._ravenClient.context(options, func, args);


### PR DESCRIPTION
Exposes `crashedLastLaunch` on iOS.  Allows the client to check after Sentry install has completed whether or not there was a crash on the previous launch.  