### PR TITLE
Don't crash on _log when Sentry is not configured.

### DIFF
--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -71,7 +71,7 @@ export const Sentry = {
   },
 
   _log(...args) {
-    if (Sentry.options.logLevel >= 2) {
+    if (Sentry.options && Sentry.options.logLevel >= 2) {
       // eslint-disable-next-line
       console.log.apply(null, args);
     }


### PR DESCRIPTION
When Sentry is not configured and you for example call `Sentry.captureMessage`, `_log` tries to pull `logLevel` out of `undefined`, as `Sentry.options` is only set when calling `Sentry.config` with a valid DSN.