### PR TITLE
Add proguard rule

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.1'
+    
+    defaultConfig {
+        consumerProguardFiles 'proguard-rules.pro'
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,4 @@
+-dontwarn javax.naming.**
+-dontwarn javax.servlet.**
+-dontwarn org.slf4j.**
+


### PR DESCRIPTION
Fixes a case when Android build if the RN project enables proguard.