### PR TITLE
Update sentry-cli path on manual-setup.rst

### DIFF
--- a/docs/manual-setup.rst
+++ b/docs/manual-setup.rst
@@ -86,11 +86,11 @@ In that case you should change the scripts to this::
     [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
     # Run sentry cli script to upload debug symbols
-    $NODE_BINARY ../node_modules/sentry-cli-binary/bin/sentry-cli upload-dsym
+    $NODE_BINARY ../node_modules/@sentry/cli/bin/sentry-cli upload-dsym
 
     # OR
 
-    $NODE_BINARY ../node_modules/sentry-cli-binary/bin/sentry-cli react-native xcode \
+    $NODE_BINARY ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode \
       ../node_modules/react-native/scripts/react-native-xcode.sh
 
 Android


### PR DESCRIPTION
I'm currently using `react-native-sentry` version `0.33.0`.
I don't know if we should be more explicit about the versions here.