### PR TITLE
Update Android compileSdkVersion and buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
     
     defaultConfig {
         consumerProguardFiles 'proguard-rules.pro'
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
The current Android compileSdkVersion, targetSdkVersion and buildToolsVersion uses the older but default version provided by the `react-native init` tool. However updating to the latest version might support possible Android build issues in scenarios where other third-party libraries require the root project to have their `compiledSdkVersion` and `buildToolsVersion` to be 25 or above. Have tested these changes in our own project and seems to be working fine without any issues.