### PR TITLE
Fixing uncatchable, crashing, exception on Android

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -91,7 +91,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void startWithDsnString(String dsnString, final ReadableMap options, Callback errorCallback, Callback successCallback) {
+    public void startWithDsnString(String dsnString, final ReadableMap options, Callback successCallback, Callback errorCallback) {
         if (sentryClient != null) {
             logger.info(String.format("Already started, use existing client '%s'", dsnString));
             return;

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -7,6 +7,7 @@ import android.support.annotation.NonNull;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -90,13 +91,20 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void startWithDsnString(String dsnString, final ReadableMap options) {
+    public void startWithDsnString(String dsnString, final ReadableMap options, Callback errorCallback, Callback successCallback) {
         if (sentryClient != null) {
             logger.info(String.format("Already started, use existing client '%s'", dsnString));
             return;
         }
 
-        sentryClient = Sentry.init(dsnString, new AndroidSentryClientFactory(this.getReactApplicationContext()));
+        try {
+            sentryClient = Sentry.init(dsnString, new AndroidSentryClientFactory(this.getReactApplicationContext()));
+        } catch (Exception e) {
+            logger.info(String.format("Catching on startWithDsnString, calling callback" + e.getMessage()));
+            errorCallback.invoke(e.getMessage());
+            return;
+        }
+
         androidHelper = new AndroidEventBuilderHelper(this.getReactApplicationContext());
         sentryClient.addEventSendCallback(new EventSendCallback() {
             @Override
@@ -143,6 +151,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             }
         });
         logger.info(String.format("startWithDsnString '%s'", dsnString));
+        successCallback.invoke("good job");
     }
 
     @ReactMethod

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -151,7 +151,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             }
         });
         logger.info(String.format("startWithDsnString '%s'", dsnString));
-        successCallback.invoke("good job");
+        successCallback.invoke();
     }
 
     @ReactMethod

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -54,22 +54,32 @@ export class NativeClient {
       deactivateStacktraceMerging: true
     };
     Object.assign(this.options, options);
+  }
 
-    RNSentry.startWithDsnString(this._dsn, this.options);
-    if (this.options.deactivateStacktraceMerging === false) {
-      this._activateStacktraceMerging();
-      const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
-      eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
-        try {
-          this._updateIgnoredModules(JSON.parse(moduleTable.payload));
-        } catch (e) {
-          // https://github.com/getsentry/react-native-sentry/issues/241
-          // under some circumstances the the JSON is not valid
-          // the reason for this is yet to be found
-        }
+  async customInit() {
+    return new Promise((resolve, reject) => {
+      RNSentry.startWithDsnString(this._dsn, this.options, () => {
+        resolve();
+      }, (err) => {
+        console.log('this is in nativeclient constructor', err);
+        reject(err);
       });
-    }
-    RNSentry.setLogLevel(options.logLevel);
+
+      if (this.options.deactivateStacktraceMerging === false) {
+        this._activateStacktraceMerging();
+        const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
+        eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
+          try {
+            this._updateIgnoredModules(JSON.parse(moduleTable.payload));
+          } catch (e) {
+            // https://github.com/getsentry/react-native-sentry/issues/241
+            // under some circumstances the the JSON is not valid
+            // the reason for this is yet to be found
+          }
+        });
+      }
+      RNSentry.setLogLevel(options.logLevel);
+    });
   }
 
   nativeCrash() {

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -61,7 +61,6 @@ export class NativeClient {
       RNSentry.startWithDsnString(this._dsn, this.options, () => {
         resolve();
       }, (err) => {
-        console.log('this is in nativeclient constructor', err);
         reject(err);
       });
 

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -21,7 +21,7 @@ export const SentryLog = {
 };
 
 export const Sentry = {
-  install() {
+  async install() {
     // We have to first setup raven otherwise react-native will freeze the options
     // and some properties like ignoreErrors can not be mutated by raven-js
     Sentry._ravenClient = new RavenClient(Sentry._dsn, Sentry.options);
@@ -31,6 +31,7 @@ export const Sentry = {
       Sentry.options.disableNativeIntegration === false
     ) {
       Sentry._nativeClient = new NativeClient(Sentry._dsn, Sentry.options);
+      await Sentry._nativeClient.customInit();
       Sentry.eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
       Sentry.eventEmitter.addListener(
         RNSentryEventEmitter.EVENT_SENT_SUCCESSFULLY,


### PR DESCRIPTION
NOTE: This does not seem to occur on iOS. We believe that it fails silently which is also an error. We have not done extensive testing there.

---

We found an issue on Android (8.1 was used) where if we used the public DSN URL we would get an exception citing that we were missing the Sentry secret. In react native, this gave us a red box with the error but it crashed our app. We tried to wrap in a try/catch but no luck. 

The error was happening asynchronously [in the Sentry Java SDK](https://github.com/getsentry/sentry-java/blob/97fc170d0eec16906e56262cfedd075f0153fa72/sentry/src/main/java/io/sentry/dsn/Dsn.java#L204) and not being broadcasted over the [RN bridge like you would expect](https://facebook.github.io/react-native/docs/native-modules-android.html#callbacks) (note this line `errorCallback.invoke(e.getMessage());`, where `errorCallback` is of type Callback from the RN Callback class), causing the error to get lost and our app unable to recover.

To fix this we wanted to `await` on the asynchronous operation. So we created a new method [`async customInit()`](https://github.com/getsentry/react-native-sentry/compare/master...scootnetworks:master?expand=1#diff-57506f97aab5514d97ada99662ff14ebR59) that returns a Promise that we await on. 

In that Promise, we resolve/reject based on if the [error](https://github.com/getsentry/react-native-sentry/compare/master...scootnetworks:master?expand=1#diff-2c23c9bdba652ccf3c4f364415d1c35cR104)/[success](https://github.com/getsentry/react-native-sentry/compare/master...scootnetworks:master?expand=1#diff-2c23c9bdba652ccf3c4f364415d1c35cR154) callback is called.

`await`ing on the `install()` method allows us to wrap that call in a try/catch in case something does throw either Native-ly or in JavaScript.

This was a very concerning bug to us, that our Error Reporting tool would throw an _**uncatchable**_ error on initialization. 

If your SDK is throwing exceptions upon startup, how will it behave now that this PR fixes the uncaught exception? If we catch this error and then another part of our code tries to capture an exception with sentry what happens? Have you thought about that?

If we had properly set the secret we never would have caught this! And in the future, if we improperly updated the secret or fat fingered the DSN URL then we would have users with essentially bricked apps that would have lost as customers.

While we have forked the repo we would hope that this would be either merged or otherwise patched in the official react-native-sentry repository.