### PR TITLE
fix: Bugfix async start / Clone Object before send over bridge

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -7,7 +7,6 @@ import android.support.annotation.NonNull;
 
 import com.facebook.react.ReactApplication;
 import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -91,20 +90,13 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void startWithDsnString(String dsnString, final ReadableMap options, Callback successCallback, Callback errorCallback) {
+    public void startWithDsnString(String dsnString, final ReadableMap options) {
         if (sentryClient != null) {
             logger.info(String.format("Already started, use existing client '%s'", dsnString));
             return;
         }
 
-        try {
-            sentryClient = Sentry.init(dsnString, new AndroidSentryClientFactory(this.getReactApplicationContext()));
-        } catch (Exception e) {
-            logger.info(String.format("Catching on startWithDsnString, calling callback" + e.getMessage()));
-            errorCallback.invoke(e.getMessage());
-            return;
-        }
-
+        sentryClient = Sentry.init(dsnString, new AndroidSentryClientFactory(this.getReactApplicationContext()));
         androidHelper = new AndroidEventBuilderHelper(this.getReactApplicationContext());
         sentryClient.addEventSendCallback(new EventSendCallback() {
             @Override
@@ -151,7 +143,6 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             }
         });
         logger.info(String.format("startWithDsnString '%s'", dsnString));
-        successCallback.invoke();
     }
 
     @ReactMethod

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -125,7 +125,10 @@ RCT_EXPORT_METHOD(crashedLastLaunch:(RCTPromiseResolveBlock)resolve
     resolve(crashedLastLaunch);
 }
 
-RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString options:(NSDictionary *_Nonnull)options)
+RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString
+                  options:(NSDictionary *_Nonnull)options
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error = nil;
     self.moduleMapping = [[NSMutableDictionary alloc] init];
@@ -152,7 +155,10 @@ RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString options:(NSD
     [SentryClient.sharedClient startCrashHandlerWithError:&error];
     if (error) {
         [NSException raise:@"SentryReactNative" format:@"%@", error.localizedDescription];
+        reject(@"SentryReactNative", error.localizedDescription, error);
+        return;
     }
+    resolve(@YES);
 }
 
 RCT_EXPORT_METHOD(activateStacktraceMerging:(RCTPromiseResolveBlock)resolve

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -75,24 +75,28 @@ export class NativeClient {
     });
   }
 
+  _cloneObject(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
   nativeCrash() {
     RNSentry.crash();
   }
 
   captureEvent(event) {
-    RNSentry.captureEvent(event);
+    RNSentry.captureEvent(this._cloneObject(event));
   }
 
   setUserContext(user) {
-    RNSentry.setUser(user);
+    RNSentry.setUser(this._cloneObject(user));
   }
 
   setTagsContext(tags) {
-    RNSentry.setTags(tags);
+    RNSentry.setTags(this._cloneObject(tags));
   }
 
   setExtraContext(extra) {
-    RNSentry.setExtra(extra);
+    RNSentry.setExtra(this._cloneObject(extra));
   }
 
   addExtraContext(key, value) {
@@ -100,7 +104,7 @@ export class NativeClient {
   }
 
   captureBreadcrumb(breadcrumb) {
-    RNSentry.captureBreadcrumb(breadcrumb);
+    RNSentry.captureBreadcrumb(this._cloneObject(breadcrumb));
   }
 
   clearContext() {

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -54,22 +54,25 @@ export class NativeClient {
       deactivateStacktraceMerging: true
     };
     Object.assign(this.options, options);
+  }
 
-    RNSentry.startWithDsnString(this._dsn, this.options);
-    if (this.options.deactivateStacktraceMerging === false) {
-      this._activateStacktraceMerging();
-      const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
-      eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
-        try {
-          this._updateIgnoredModules(JSON.parse(moduleTable.payload));
-        } catch (e) {
-          // https://github.com/getsentry/react-native-sentry/issues/241
-          // under some circumstances the the JSON is not valid
-          // the reason for this is yet to be found
-        }
-      });
-    }
-    RNSentry.setLogLevel(options.logLevel);
+  async install() {
+    return RNSentry.startWithDsnString(this._dsn, this.options).then(() => {
+      if (this.options.deactivateStacktraceMerging === false) {
+        this._activateStacktraceMerging();
+        const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
+        eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
+          try {
+            this._updateIgnoredModules(JSON.parse(moduleTable.payload));
+          } catch (e) {
+            // https://github.com/getsentry/react-native-sentry/issues/241
+            // under some circumstances the the JSON is not valid
+            // the reason for this is yet to be found
+          }
+        });
+      }
+      RNSentry.setLogLevel(this.options.logLevel);
+    });
   }
 
   nativeCrash() {

--- a/lib/NativeClient.js
+++ b/lib/NativeClient.js
@@ -54,31 +54,22 @@ export class NativeClient {
       deactivateStacktraceMerging: true
     };
     Object.assign(this.options, options);
-  }
 
-  async customInit() {
-    return new Promise((resolve, reject) => {
-      RNSentry.startWithDsnString(this._dsn, this.options, () => {
-        resolve();
-      }, (err) => {
-        reject(err);
+    RNSentry.startWithDsnString(this._dsn, this.options);
+    if (this.options.deactivateStacktraceMerging === false) {
+      this._activateStacktraceMerging();
+      const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
+      eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
+        try {
+          this._updateIgnoredModules(JSON.parse(moduleTable.payload));
+        } catch (e) {
+          // https://github.com/getsentry/react-native-sentry/issues/241
+          // under some circumstances the the JSON is not valid
+          // the reason for this is yet to be found
+        }
       });
-
-      if (this.options.deactivateStacktraceMerging === false) {
-        this._activateStacktraceMerging();
-        const eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
-        eventEmitter.addListener(RNSentryEventEmitter.MODULE_TABLE, moduleTable => {
-          try {
-            this._updateIgnoredModules(JSON.parse(moduleTable.payload));
-          } catch (e) {
-            // https://github.com/getsentry/react-native-sentry/issues/241
-            // under some circumstances the the JSON is not valid
-            // the reason for this is yet to be found
-          }
-        });
-      }
-      RNSentry.setLogLevel(options.logLevel);
-    });
+    }
+    RNSentry.setLogLevel(options.logLevel);
   }
 
   nativeCrash() {

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -43,9 +43,20 @@ export const Sentry = {
         if (Sentry._internalEventStored) Sentry._internalEventStored();
       });
     }
-    // We need to call install here since this add the callback for sending events
-    // over the native bridge
-    Sentry._ravenClient.install();
+    if (Sentry._nativeClient) {
+      Sentry._nativeClient
+        .install()
+        .then(() => {
+          Sentry._ravenClient.install();
+        })
+        .catch(error => {
+          throw error;
+        });
+    } else {
+      // We need to call install here since this add the callback for sending events
+      // over the native bridge
+      Sentry._ravenClient.install();
+    }
   },
 
   config(dsn, options) {

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -21,7 +21,7 @@ export const SentryLog = {
 };
 
 export const Sentry = {
-  async install() {
+  install() {
     // We have to first setup raven otherwise react-native will freeze the options
     // and some properties like ignoreErrors can not be mutated by raven-js
     Sentry._ravenClient = new RavenClient(Sentry._dsn, Sentry.options);
@@ -31,7 +31,6 @@ export const Sentry = {
       Sentry.options.disableNativeIntegration === false
     ) {
       Sentry._nativeClient = new NativeClient(Sentry._dsn, Sentry.options);
-      await Sentry._nativeClient.customInit();
       Sentry.eventEmitter = new NativeEventEmitter(RNSentryEventEmitter);
       Sentry.eventEmitter.addListener(
         RNSentryEventEmitter.EVENT_SENT_SUCCESSFULLY,


### PR DESCRIPTION
This makes the start call async more info here:
https://github.com/getsentry/react-native-sentry/pull/355
I've changed it so it works for iOS and Android.

Fixes https://github.com/getsentry/react-native-sentry/issues/347