### PR TITLE
Make sentry.gradle include all ABIs version codes as dist

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -11,7 +11,12 @@ gradle.projectsEvaluated {
         def releaseName = "${variant.getApplicationId()}-${variant.getVersionName()}";
         variant.outputs.each { output ->
             def versionCode = output.getVersionCode();
-            releases[variant.getName()] = [output.getName(), releaseName, versionCode];
+            def variantName = variant.getName();
+            def outputName = output.getName();
+            if (releases[variantName] == null) {
+                releases[variantName] = [:];
+            }
+            releases[variantName][outputName] = [outputName, releaseName, versionCode];
         }
     }
     // separately we then hook into the bundle task of react native to inject
@@ -63,26 +68,32 @@ gradle.projectsEvaluated {
         //     .findAll{!['class', 'active'].contains(it.key)}
         //     .join('\n')
 
-        def currentVariant = "";
+        def currentRelease = "";
         def pattern = Pattern.compile("bundle([A-Z][A-Za-z0-9]+)JsAndAssets")
         Matcher matcher = pattern.matcher(bundleTask.name)
         if (matcher.find()) {
             def match = matcher.group(1);
-            currentVariant = match.substring(0, 1).toLowerCase() + match.substring(1);
+            currentRelease = match.substring(0, 1).toLowerCase() + match.substring(1);
         }
 
-        def currentRelease = null;
+        def currentVariants = null;
         releases.each { key, release ->
-            if (key == currentVariant) {
-                currentRelease = release;
+            if (key == currentRelease) {
+                currentVariants = release;
             }
         }
 
-        if (currentRelease == null) return;
+        def variant = null;
+        def releaseName = null;
+        def versionCodes = new ArrayList<Integer>(currentVariants.size());
 
-        def variant = currentRelease[0]
-        def releaseName = currentRelease[1]
-        def versionCodes = currentRelease[2]
+        if (currentVariants == null) return;
+
+        currentVariants.each { key, currentVariant ->
+            variant = currentVariant[0];
+            releaseName = currentVariant[1];
+            versionCodes.push(currentVariant[2]);
+        }
 
         def cliTask = tasks.create(
             name: bundleTask.getName() + variant + "SentryUpload",


### PR DESCRIPTION
Hi!

I've encountered an issue that I haven't find a way how to resolve.

My Android app (and any other React Native app that uses default settings) have builds for 2 ABIs: `"x86"` and `"armeabi-v7a"`. App versions with different ABIs should have different version codes as per Google Play Store requirements.

The issue is that on each build `react-native-sentry` took only one version code on each build, which makes source maps work only for a version of the app with "lucky" ABI (I believe it's the last of alphabetically sorted list) which version code was used as `--dist` argument on source maps upload. 

But for source maps to work on all ABIs, all of their version codes should be accounted.

There's a code in `sentry.gradle`:
```
versionCodes.each { versionCode ->
    args.add("--dist");
    args.add(versionCode);
}
```

However, to date `versionCodes` isn't an array of any sort but a single value.

I wonder why haven't anyone run into this issue before.

This PR should fix this issue. It may break flavor support, I'm not sure, but with your help I think we could fix my issue in the best way possible.