### PR TITLE
fix: Make install async to make it catchable

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -93,6 +93,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     public void startWithDsnString(String dsnString, final ReadableMap options, Promise promise) {
         if (sentryClient != null) {
             logger.info(String.format("Already started, use existing client '%s'", dsnString));
+            promise.resolve(false);
             return;
         }
 

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -259,12 +259,13 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             ReadableNativeArray exceptionValues = (ReadableNativeArray)event.getMap("exception").getArray("values");
             ReadableNativeMap exception = exceptionValues.getMap(0);
             ReadableNativeMap stacktrace = exception.getMap("stacktrace");
+            ReadableNativeArray frames = (ReadableNativeArray)stacktrace.getArray("frames");
             if (exception.hasKey("value")) {
-                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("value"), stacktrace.getArray("frames"));
+                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("value"), frames);
             } else {
                 // We use type/type here since this indicates an Unhandled Promise Rejection
                 // https://github.com/getsentry/react-native-sentry/issues/353
-                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("type"), stacktrace.getArray("frames"));
+                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("type"), frames);
             }
         }
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -154,7 +154,6 @@ RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString
     [SentryClient setSharedClient:client];
     [SentryClient.sharedClient startCrashHandlerWithError:&error];
     if (error) {
-        [NSException raise:@"SentryReactNative" format:@"%@", error.localizedDescription];
         reject(@"SentryReactNative", error.localizedDescription, error);
         return;
     }

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -21,7 +21,7 @@ export const SentryLog = {
 };
 
 export const Sentry = {
-  install() {
+  async install() {
     // We have to first setup raven otherwise react-native will freeze the options
     // and some properties like ignoreErrors can not be mutated by raven-js
     Sentry._ravenClient = new RavenClient(Sentry._dsn, Sentry.options);
@@ -44,18 +44,13 @@ export const Sentry = {
       });
     }
     if (Sentry._nativeClient) {
-      Sentry._nativeClient
-        .install()
-        .then(() => {
-          Sentry._ravenClient.install();
-        })
-        .catch(error => {
-          throw error;
-        });
+      return Sentry._nativeClient.install().then(() => {
+        Sentry._ravenClient.install();
+      });
     } else {
       // We need to call install here since this add the callback for sending events
       // over the native bridge
-      Sentry._ravenClient.install();
+      return Sentry._ravenClient.install();
     }
   },
 


### PR DESCRIPTION
Now you can do this to "catch" a possible misconfiguration with the DSN
```
Sentry.config(sentryDsn, {
  logLevel: SentryLog.Debug,
  deactivateStacktraceMerging: false
})
  .install()
  .catch(error => {
    console.log(error);
  });
```
cc @cworsley4 

Also fixes #354 