### PR TITLE
fix: Check for Unhandled js exception

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 3.10.0'
-  s.dependency 'Sentry/KSCrash', '~> 3.10.0'
+  s.dependency 'Sentry', '~> 3.11.1'
+  s.dependency 'Sentry/KSCrash', '~> 3.11.1'
 
   s.source_files = 'ios/RNSentry*.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/docs/cocoapods.rst
+++ b/docs/cocoapods.rst
@@ -11,33 +11,15 @@ In order to use Sentry with CocoaPods you have to install the packages with
     npm install --save react react-native react-native-sentry
 
 After that change your ``Podfile`` to reference to the packages in your
-``node_modules`` folder.
+``node_modules`` folder. For the latest reference of how to use react-native with
+CocoaPods see: `https://facebook.github.io/react-native/docs/integration-with-existing-apps.html#configuring-cocoapods-dependencies`_
 
 .. sourcecode:: ruby
 
-    platform :ios, '8.0'
-    use_frameworks!
-
-    node_modules_path = './node_modules' # This path can be different depending on you setup
-    react_path = File.join(node_modules_path, 'react-native')
-    yoga_path = File.join(react_path, 'ReactCommon/yoga')
-    sentry_path = File.join(node_modules_path, 'react-native-sentry')
-
     target 'YOUR-TARGET' do
-        pod 'Yoga', :path => yoga_path
-        pod 'React', :path => react_path, :subspecs => [
-          'Core',
-          'BatchedBridge',
-          'RCTImage',
-          'RCTNetwork',
-          'RCTText',
-          'RCTWebSocket'
-          # Add any other subspecs you want to use in your project
-        ]
-        pod 'SentryReactNative', :path => sentry_path
+        # Your react-native and other pods
+
+        pod 'SentryReactNative', :path => '../node_modules/react-native-sentry/SentryReactNative.podspec' # or your path to node_modules
     end
 
 After that run ``pod install`` which then should link everything correctly.
-If you need more information about how to load the react view check out
-`this tutorial.
-<https://facebook.github.io/react-native/releases/docs/embedded-app-ios.html>`_

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -138,11 +138,11 @@ RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString
         [self setReleaseVersionDist:event];
     };
     client.shouldSendEvent = ^BOOL(SentryEvent * _Nonnull event) {
-        // We don't want to send an event after startup that came from a NSException of react native
+        // We don't want to send an event after startup that came from a Unhandled JS Exception of react native
         // Because we sent it already before the app crashed.
         if (nil != event.exceptions.firstObject.type &&
-            [event.exceptions.firstObject.type rangeOfString:@"RCTFatalException"].location != NSNotFound) {
-            NSLog(@"RCTFatalException");
+            [event.exceptions.firstObject.type rangeOfString:@"Unhandled JS Exception"].location != NSNotFound) {
+            NSLog(@"Unhandled JS Exception");
             return NO;
         }
         // Since we set shouldSendEvent for react-native we need to duplicate the code for sampling here

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "preversion:changelog": "grep -q -F \"## v$npm_package_version\" CHANGELOG.md",
     "version": "npm run preversion:changelog && node ./scripts/version-bump.js && git add -A",
     "precommit": "lint-staged",
-    "test:typescript": "node_modules/typescript/bin/tsc --noImplicitAny --allowJs typescript/Sentry-tests.ts"
+    "test:typescript": "node_modules/typescript/bin/tsc --noImplicitAny --allowJs typescript/Sentry-tests.ts",
+    "postinstall": "node scripts/postinstall.js"
   },
   "keywords": [
     "react-native",
@@ -28,7 +29,7 @@
     "react-native": ">=0.38.0"
   },
   "dependencies": {
-    "@sentry/wizard": "^0.8.1",
+    "@sentry/wizard": "^0.9.1",
     "raven-js": "^3.22.1"
   },
   "rnpm": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "preversion:changelog": "grep -q -F \"## v$npm_package_version\" CHANGELOG.md",
     "version": "npm run preversion:changelog && node ./scripts/version-bump.js && git add -A",
     "precommit": "lint-staged",
-    "test:typescript": "node_modules/typescript/bin/tsc --noImplicitAny --allowJs typescript/Sentry-tests.ts",
-    "postinstall": "node scripts/postinstall.js"
+    "test:typescript": "node_modules/typescript/bin/tsc --noImplicitAny --allowJs typescript/Sentry-tests.ts"
   },
   "keywords": [
     "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,26 +2,35 @@
 # yarn lockfile v1
 
 
-"@sentry/cli@^1.28.4":
-  version "1.28.4"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.28.4.tgz#82e7b30dfa1294ad56870690858c37135aac20df"
+"@sentry/cli@^1.30.1":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.30.2.tgz#ead724c661920acda9b37779613dab7b0be9d828"
   dependencies:
+    https-proxy-agent "^2.1.1"
+    node-fetch "^1.7.3"
     progress "2.0.0"
+    proxy-from-env "^1.0.0"
 
-"@sentry/wizard@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-0.8.1.tgz#fc2f2ae10b4b4cdd60ce68cd68adf79d535219fb"
+"@sentry/wizard@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-0.9.1.tgz#f047672f03184f2fb20224775cefebd1f176795b"
   dependencies:
-    "@sentry/cli" "^1.28.4"
-    chalk "^2.3.0"
+    "@sentry/cli" "^1.30.1"
+    chalk "^2.3.1"
     glob "^7.1.2"
-    inquirer "^5.0.1"
-    lodash "^4.17.4"
+    inquirer "^5.1.0"
+    lodash "^4.17.5"
     open "^0.0.5"
     r2 "^2.0.0"
     read-env "^1.1.1"
     xcode "^1.0.0"
     yargs "^11.0.0"
+
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ansi-escapes@^1.0.0:
   version "1.4.0"
@@ -46,6 +55,12 @@ ansi-styles@^2.2.1:
 ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -119,6 +134,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -232,11 +255,27 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -342,6 +381,17 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+https-proxy-agent@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz#7fbba856be8cd677986f42ebd3664f6317257887"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
@@ -350,7 +400,7 @@ husky@^0.14.3:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
-iconv-lite@^0.4.17:
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -375,9 +425,9 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.0.1.tgz#5c0396c974fd98df4cab9afd26ed85874b563550"
+inquirer@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.1.0.tgz#19da508931892328abbbdd4c477f1efc65abfd67"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.0"
@@ -455,7 +505,7 @@ is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -585,6 +635,10 @@ lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -634,6 +688,13 @@ ms@2.0.0:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+node-fetch@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-fetch@^2.0.0-alpha.8:
   version "2.0.0-alpha.9"
@@ -783,6 +844,10 @@ pretty-format@^21.2.1:
 progress@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -964,6 +1029,12 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This fixes an issue where if an error occurs in a module, we do not send the event to Sentry because it's always a `RCTFatalException`.
This makes the check more explicit.
Also updated CocoaPods docs.