### PR TITLE
Remove obsolete React podspec dependency

### DIFF
--- a/SentryReactNative.podspec
+++ b/SentryReactNative.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = '*.js'
 
-  s.dependency 'React'
   s.dependency 'Sentry', '~> 3.12.0'
   s.dependency 'Sentry/KSCrash', '~> 3.12.0'
 


### PR DESCRIPTION
I'm using Sentry with a `React Native`-only app.

`react-native link react-native-sentry` adds `RNSentry` as a pod. If I include `React` as a pod in `Podfile`, all is ok. But I explicitly do not include `React` as a pod in my `React Native`-only app, because it has many downsides and using-react-as-a-pod-issues. In this case `Sentry`-pod forces CocoaPods to satisfy this (check the changes of this PR) `React`-dependency by installing old/obsolete/deprecated `React` `0.11`, which breaks even more things.

Resolution is to remove this dependency.

Check corresponding issues in another repos:

invertase/react-native-firebase#325
invertase/react-native-firebase#324

ocetnik/react-native-background-timer#71