### PR TITLE
fix: Fixed sentry.gradle to do the case insensitive search of build...

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -78,7 +78,7 @@ gradle.projectsEvaluated {
 
         def currentVariants = null;
         releases.each { key, release ->
-            if (key == currentRelease) {
+            if (key.equalsIgnoreCase(currentRelease)) {
                 currentVariants = release;
             }
         }


### PR DESCRIPTION
 …variant

I've encountered a problem in my Android project that sentry didn't upload source maps. It turned out that it was comparing the key of release with current release by usual equality, while my current release was like myRelease and in releases array it was MyRelease. So by ignoring case that shouldn't happen anymore.