### PR TITLE
Expose async `install` signature in typescript def

### DIFF
--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -42,7 +42,7 @@ interface SentryOptions {
 export default Sentry;
 
 export class Sentry {
-  install(): void;
+  install(): Promise<void>;
 
   static config(dsn: string, options?: SentryOptions): Sentry;
 


### PR DESCRIPTION
Since `install` is async, it might make sense for a user to want to ensure sentry is completely installed before doing some other work, in order to not miss any messages/exceptions that might occur. With the current type def, this requires a nasty typecast from typescript (eg. `(Sentry.config(...).install() as any as Promise<void>).then(...)`), so let's expose `install`'s async signature properly.