### PR TITLE
Fix codepush docs

### DIFF
--- a/docs/codepush.rst
+++ b/docs/codepush.rst
@@ -20,9 +20,9 @@ Make sure that you call this function otherwise Sentry is not able to symbolicat
 
 After updating your CodePush release you have to upload the new assets to Sentry::
 
-    $ appcenter codepush release-react YourApp ios --outputDir build
+    $ appcenter codepush release-react YourApp --output-dir build
     $ export SENTRY_PROPERTIES=./ios/sentry.properties
-    $ sentry-cli react-native codepush YourApp ios ./build
+    $ sentry-cli react-native appcenter YourApp ios build
 
 .. admonition:: Note
 

--- a/docs/codepush.rst
+++ b/docs/codepush.rst
@@ -20,9 +20,9 @@ Make sure that you call this function otherwise Sentry is not able to symbolicat
 
 After updating your CodePush release you have to upload the new assets to Sentry::
 
-    $ appcenter codepush release-react YourApp --output-dir build
+    $ appcenter codepush release-react YourApp --output-dir ./build
     $ export SENTRY_PROPERTIES=./ios/sentry.properties
-    $ sentry-cli react-native appcenter YourApp ios build
+    $ sentry-cli react-native appcenter YourApp ios ./build/codePush
 
 .. admonition:: Note
 


### PR DESCRIPTION
Updated the appcenter CLI examples so they are up to date with the current commands.

```bash
$ appcenter codepush release-react YourApp --output-dir ./build
```

exports the bundle files to `./build/codePush/<files>` so this is now reflected in 

```
$ sentry-cli react-native appcenter YourApp ios ./build/codePush
```

(related: https://github.com/getsentry/sentry-cli/issues/233)


