### PR TITLE
Improve typings

### DIFF
--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -31,12 +31,12 @@ export enum SentryLog {
 }
 
 interface SentryOptions {
-  logLevel?: SentryLog;
-  instrument?: boolean;
+  deactivateStacktraceMerging: boolean;
   disableNativeIntegration?: boolean;
   ignoreModulesExclude?: [string];
   ignoreModulesInclude?: [string];
-  deactivateStacktraceMerging: boolean;
+  instrument?: boolean;
+  logLevel?: SentryLog;
 }
 
 export default Sentry;

--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -32,7 +32,7 @@ export enum SentryLog {
 
 interface SentryOptions {
   /** Deactivates the stacktrace merging feature. Default: true */
-  deactivateStacktraceMerging: boolean;
+  deactivateStacktraceMerging?: boolean;
   /** Deactivates the native integration and only uses raven-js */
   disableNativeIntegration?: boolean;
   /** Handle unhandled promise rejections. Default: true */

--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -33,8 +33,8 @@ export enum SentryLog {
 interface SentryOptions {
   deactivateStacktraceMerging: boolean;
   disableNativeIntegration?: boolean;
-  ignoreModulesExclude?: [string];
-  ignoreModulesInclude?: [string];
+  ignoreModulesExclude?: string[];
+  ignoreModulesInclude?: string[];
   instrument?: boolean;
   logLevel?: SentryLog;
 }

--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -31,11 +31,14 @@ export enum SentryLog {
 }
 
 interface SentryOptions {
+  /** Deactivates the stacktrace merging feature. Default: true */
   deactivateStacktraceMerging: boolean;
+  /** Deactivates the native integration and only uses raven-js */
   disableNativeIntegration?: boolean;
   ignoreModulesExclude?: string[];
   ignoreModulesInclude?: string[];
   instrument?: boolean;
+  /** Sentry log level. Default: SentryLog.None */
   logLevel?: SentryLog;
 }
 

--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -35,6 +35,8 @@ interface SentryOptions {
   deactivateStacktraceMerging: boolean;
   /** Deactivates the native integration and only uses raven-js */
   disableNativeIntegration?: boolean;
+  /** Handle unhandled promise rejections. Default: true */
+  handlePromiseRejection?: boolean;
   ignoreModulesExclude?: string[];
   ignoreModulesInclude?: string[];
   instrument?: boolean;


### PR DESCRIPTION
This PR improve typescript definitions slightly. For `SentryOptions`:
- Add missing `handlePromiseRejection` option
- Fix typings for `ignoreModulesExclude` and `ignoreModulesInclude`
- Fix type of `deactivateStacktraceMerging` to be optional (or `npm run test:typescript` failing, does it run in CI?)
- Add doc comments for some options

Also I have one question. There is `instrument` option, but I can find it only in default values in file: https://github.com/getsentry/react-native-sentry/blob/727dca6f7e516191ea646ff9b0ce5c3e9674e4b9/lib/Sentry.js#L64 
Does it used at all?
