### PR TITLE
Check project properties to get sdk version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,20 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.3'
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('compileSdkVersion', '26.0.3')
 
     defaultConfig {
         consumerProguardFiles 'proguard-rules.pro'
     }
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
This PR allows a library user to define Android SDK version. It is a common practice in React Native community to check project level properties in `rootProject.ext` for that.