### PR TITLE
Fix: :bug: Was not getting buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 26)
-    buildToolsVersion safeExtGet('compileSdkVersion', '26.0.3')
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
         consumerProguardFiles 'proguard-rules.pro'


### PR DESCRIPTION
Lead to the error message:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/Users/me/Apps/mobile-app/node_modules/react-native-sentry/android/build.gradle' line: 9

* What went wrong:
A problem occurred evaluating project ':react-native-sentry'.
> Could not find method buildToolsVersion() for arguments [27] on object of type com.android.build.gradle.LibraryExtension.
```