### PR TITLE
Replace deprecated 'compile' gradle configuration with 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    implementaion 'com.facebook.react:react-native:+'
-    implementaion 'io.sentry:sentry-android:1.7.5'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'io.sentry:sentry-android:1.7.5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'io.sentry:sentry-android:1.7.5'
+    implementaion 'com.facebook.react:react-native:+'
+    implementaion 'io.sentry:sentry-android:1.7.5'
 }


### PR DESCRIPTION
According to [ReactNative@0.57](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#057) default gradle version is now `4.4`.