### PR TITLE
Add return case to ensure normalised url is a file path (begins /) after 'app://'

### DIFF
--- a/lib/raven-plugin.js
+++ b/lib/raven-plugin.js
@@ -41,9 +41,14 @@ var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
 
 /**
  * Strip device-specific IDs from React Native file:// paths
+ * Ensure path begins with / (after app://) to ensure source code and map path can be found
  */
 function normalizeUrl(url, pathStripRe) {
-  return 'app://' + url.replace(/^file\:\/\//, '').replace(pathStripRe, '');
+  const normUrl = url.replace(/^file\:\/\//, '').replace(pathStripRe, '');
+  if (normUrl.indexOf('/') !== 0) {
+    return 'app:///' + normUrl;
+  }
+  return 'app://' + normUrl;
 }
 
 /**


### PR DESCRIPTION
- Addresses an issue events (on Android platform) are being sent with `transaction` context value `app://index.android.bundle` rather than `app:///index.android.bundle` which means source code cannot be found
- Related to issue https://github.com/getsentry/react-native-sentry/issues/531