### PR TITLE
Checking if stacktrace exists before accessing it

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -265,14 +265,16 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
         if (event.hasKey("exception")) {
             ReadableNativeArray exceptionValues = (ReadableNativeArray)event.getMap("exception").getArray("values");
             ReadableNativeMap exception = exceptionValues.getMap(0);
-            ReadableNativeMap stacktrace = exception.getMap("stacktrace");
-            ReadableNativeArray frames = (ReadableNativeArray)stacktrace.getArray("frames");
-            if (exception.hasKey("value")) {
-                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("value"), frames);
-            } else {
-                // We use type/type here since this indicates an Unhandled Promise Rejection
-                // https://github.com/getsentry/react-native-sentry/issues/353
-                addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("type"), frames);
+            if (exception.hasKey("stacktrace")) {
+                ReadableNativeMap stacktrace = exception.getMap("stacktrace");
+                ReadableNativeArray frames = (ReadableNativeArray)stacktrace.getArray("frames");
+                if (exception.hasKey("value")) {
+                    addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("value"), frames);
+                } else {
+                    // We use type/type here since this indicates an Unhandled Promise Rejection
+                    // https://github.com/getsentry/react-native-sentry/issues/353
+                    addExceptionInterface(eventBuilder, exception.getString("type"), exception.getString("type"), frames);
+                }
             }
         }
 


### PR DESCRIPTION
Ran into this react native error even when not using Sentry. Sentry will crash (and crash your RN app with it) if stacktrace doesn't exist. This adds a check for stacktrace just like the checks being performed in the immediate vicinity of this code.

Related to issue #487 